### PR TITLE
gnome: move adwaita-icon-theme to top-level

### DIFF
--- a/vm.nix
+++ b/vm.nix
@@ -16,7 +16,7 @@
     spice-protocol
     win-virtio
     win-spice
-    gnome.adwaita-icon-theme
+    adwaita-icon-theme
   ];
 
   # Manage the virtualisation services


### PR DESCRIPTION
The 'gnome.adwaita-icon-theme' attribute was deprecated and moved to pkgs.adwaita-icon-theme. Update environment system packages to reference the new top-level attribute to avoid errors during evaluation.